### PR TITLE
Disabled Swiper for desktops

### DIFF
--- a/src/css/faq.css
+++ b/src/css/faq.css
@@ -55,7 +55,7 @@
 
 .accordion-header:hover,
 .accordion-header:focus {
-  text-shadow:  2px 2px 4px rgba(113, 24, 163, 0.8);
+  text-shadow:  0 4px 4px 0 rgba(113, 24, 163, 0.23);
 }
 
 .accordion-icon {
@@ -71,8 +71,7 @@
 .accordion-content {
   font-weight: 300;
   transition: all 0.3s ease;
-  padding: 0 43px 0 0;
-  
+  padding: 0 43px 0 0;  
 }
 
 [data-visible='hidden'] {

--- a/src/js/game-features.js
+++ b/src/js/game-features.js
@@ -1,32 +1,40 @@
 import Swiper from 'swiper';
-import { Navigation, Pagination, Scrollbar, Autoplay } from 'swiper/modules';
+import { Pagination, Autoplay } from 'swiper/modules';
 import 'swiper/css';
 import 'swiper/css/navigation';
 import 'swiper/css/pagination';
 import 'swiper/css/scrollbar';
 
-Swiper.use([Navigation, Pagination, Scrollbar, Autoplay]);
+let featuresSwiper;
 
-new Swiper('.game-features-swiper', {
-  modules: [Pagination, Autoplay],
-  slidesPerView: 1,
-  spaceBetween: 20,
-  pagination: {
-    el: '.swiper-pagination',
-    clickable: true,
-  },
-  autoplay: {
-    delay: 4000,
-    disableOnInteraction: false,
-  },
-  breakpoints: {
-    320: {
+const screenWidthQuery = window.matchMedia('(max-width: 1199.98px)');
+
+function initFeaturesSwiper() {
+  if (screenWidthQuery.matches && !featuresSwiper) {
+    featuresSwiper = new Swiper('.game-features-swiper', {
+      modules: [Pagination, Autoplay],
       slidesPerView: 1,
-      allowTouchMove: true,
-    },
-    1200: {
-      slidesPerView: 4,
-      allowTouchMove: true,
-    },
-  },
-});
+      spaceBetween: 20,
+      pagination: {
+        el: '.swiper-pagination',
+        clickable: true,
+      },
+      autoplay: {
+        delay: 4000,
+        disableOnInteraction: false,
+      },
+      breakpoints: {
+        320: {
+          slidesPerView: 1,
+          allowTouchMove: true,
+        },
+      },
+    });
+  } else if (!screenWidthQuery.matches && featuresSwiper) {
+    featuresSwiper.destroy(true, true);
+    featuresSwiper = null;
+  }
+}
+
+initFeaturesSwiper();
+screenWidthQuery.addEventListener('change', initFeaturesSwiper);

--- a/src/js/get-started.js
+++ b/src/js/get-started.js
@@ -5,7 +5,6 @@ import {
   Pagination,
   Scrollbar,
   Autoplay,
-  EffectCoverflow,
 } from 'swiper/modules';
 import 'swiper/css';
 import 'swiper/css/navigation';


### PR DESCRIPTION
Refactored the JavaScript code so that the Swiper slider disables automatically when the screen width is 1200px or wider.